### PR TITLE
allow where() to cope with empty arrays

### DIFF
--- a/FluentPDO/CommonQuery.php
+++ b/FluentPDO/CommonQuery.php
@@ -50,6 +50,8 @@ abstract class CommonQuery extends BaseQuery {
 			# condition is column only
 			if (is_null($parameters)) {
 				return $this->addStatement('WHERE', "$condition is NULL");
+			} elseif ($args[1] === []) {
+				return $this->addStatement('WHERE', 'FALSE');
 			} elseif (is_array($args[1])) {
 				$in = $this->quote($args[1]);
 				return $this->addStatement('WHERE', "$condition IN $in");


### PR DESCRIPTION
generate "WHERE FALSE"
instead of "WHERE field IN ()" which is invalid SQL
