### PR TITLE
always disable smart join by default

### DIFF
--- a/FluentPDO/CommonQuery.php
+++ b/FluentPDO/CommonQuery.php
@@ -8,7 +8,7 @@ abstract class CommonQuery extends BaseQuery {
 	protected $joins = array();
 
 	/** @var boolean disable adding undefined joins to query? */
-	protected $isSmartJoinEnabled = true;
+	protected $isSmartJoinEnabled = false;
 
 	public function enableSmartJoin() {
 		$this->isSmartJoinEnabled = true;


### PR DESCRIPTION
This page breaks for me https://staging.tutorfair.com/tutor/name/justin/id/676/profile

(but you don't get a fairy on prod because https://github.com/Tutorfair/fluentpdo/blob/master/FluentPDO/BaseQuery.php#L120)

# Question
Have we ever intentionally used Fluent's "smart join" feature?
# for
# Seb
# here
Have we ever intentionally used Fluent's "smart join" feature?
# hi
# Seb
Have we ever intentionally used Fluent's "smart join" feature?
# how
# are
# you
Have we ever intentionally used Fluent's "smart join" feature?
# do
# you
# have
# any
# holiday
# plans
# for
# the
# Summer
Have we ever intentionally used Fluent's "smart join" feature?
# did
# you
# notice
# the
# question
Have we ever intentionally used Fluent's "smart join" feature?

I have [created a bug on Pivotal](https://www.pivotaltracker.com/story/show/150358170)